### PR TITLE
Improve verbose

### DIFF
--- a/distriploy/distriploy.py
+++ b/distriploy/distriploy.py
@@ -55,6 +55,8 @@ def release(repo_path, revision, config):
 
     mod = get_module(release_method_name, "release")
 
+    print("Release on: " + release_method_name)
+
     return mod.release(repo_path, revision, cfg_release)
 
 
@@ -71,6 +73,7 @@ def mirror(repo_path, config, release_meta):
 
         try:
             mod = get_module(mirror_method_name, "mirror")
+            print("Mirroring on: " + mirror)
         except ModuleNotFoundError as e:
             logger.exception("Mirroring plug-in %s (%s) not found, skipping",
              mirror, mirror_method_name)


### PR DESCRIPTION
I tried implementing the output with logging, but it doesn't seem to work when trying to output logging.info.

Fixes https://github.com/neuropoly/distriploy/issues/14

Output example:
```
[1/02/21 2:09:14] (base) alex@NeuroPoly-MacBook-Pro dev_distriploy % distriploy --revision test_v0.0 release
Release on: github
Mirroring on: osf
["https://github.com/alexfoias/dev_distriploy/releases/download/test_v0.0/dev_distriploy-test_v0.0.zip", "https://files.ca-1.osf.io/v1/resources/rfp63/providers/osfstorage/60185224c5784b0543d02fc0"]
```